### PR TITLE
Declare internal source attributes in consuming projects

### DIFF
--- a/IDisposableAnalyzers/IDisposableAnalyzers.csproj
+++ b/IDisposableAnalyzers/IDisposableAnalyzers.csproj
@@ -66,7 +66,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="tools\*" Pack="true" PackagePath="" />
+    <None Update="tools\*;build\*" Pack="true" PackagePath="" />
+    <Compile Remove="build\*.cs" />
+    <None Include="build\*.cs" Pack="true" PackagePath="build" />
+
     <None Include="$(OutputPath)\$(AssemblyName).dll;$(OutputPath)\Gu.Roslyn.Extensions.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 </Project>

--- a/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
+++ b/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
@@ -1,0 +1,13 @@
+<Project>
+
+  <PropertyGroup>
+    <OwnershipAttributesPath Condition="'$(OwnershipAttributesPath)' == ''">$(MSBuildThisFileDirectory)OwnershipAttributes$(DefaultLanguageSourceExtension)</OwnershipAttributesPath>
+
+    <IncludeOwnershipAttributes Condition="'$(IncludeOwnershipAttributes)' == '' and Exists($(OwnershipAttributesPath))">true</IncludeOwnershipAttributes>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IncludeOwnershipAttributes)' == 'true'">
+    <Compile Include="$(OwnershipAttributesPath)" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
+++ b/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
@@ -8,6 +8,9 @@
 
   <ItemGroup Condition="'$(IncludeOwnershipAttributes)' == 'true'">
     <Compile Include="$(OwnershipAttributesPath)" Visible="false" />
+
+    <!-- Workaround for https://github.com/dotnet/wpf/issues/810 -->
+    <_GeneratedCodeFiles Include="$(OwnershipAttributesPath)" Visible="false" Condition="'$(UseWPF)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
+++ b/IDisposableAnalyzers/build/IDisposableAnalyzers.targets
@@ -6,11 +6,18 @@
     <IncludeOwnershipAttributes Condition="'$(IncludeOwnershipAttributes)' == '' and Exists($(OwnershipAttributesPath))">true</IncludeOwnershipAttributes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IncludeOwnershipAttributes)' == 'true'">
+  <ItemGroup Condition="'$(IncludeOwnershipAttributes)' == 'true' and Exists($(OwnershipAttributesPath))">
     <Compile Include="$(OwnershipAttributesPath)" Visible="false" />
 
     <!-- Workaround for https://github.com/dotnet/wpf/issues/810 -->
     <_GeneratedCodeFiles Include="$(OwnershipAttributesPath)" Visible="false" Condition="'$(UseWPF)' == 'true'" />
   </ItemGroup>
+
+  <Target Name="OwnershipAttributesRequestedForUnsupportedLanguage"
+          Condition="'$(IncludeOwnershipAttributes)' == 'true' and !Exists($(OwnershipAttributesPath))"
+          BeforeTargets="Compile">
+
+    <Warning Code="IDISP026" Text="The project specifies &lt;IncludeOwnershipAttributes&gt;true&lt;/IncludeOwnershipAttributes&gt;, but including attributes in this language is not yet supported." />
+  </Target>
 
 </Project>

--- a/IDisposableAnalyzers/build/OwnershipAttributes.cs
+++ b/IDisposableAnalyzers/build/OwnershipAttributes.cs
@@ -1,0 +1,28 @@
+namespace IDisposableAnalyzers
+{
+    using System;
+
+    /// <summary>
+    /// The return value must be disposed by the caller.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    internal sealed class GivesOwnershipAttribute : Attribute
+    {
+    }
+
+    /// <summary>
+    /// The return value must not be disposed by the caller.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.ReturnValue | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    internal sealed class KeepsOwnershipAttribute : Attribute
+    {
+    }
+
+    /// <summary>
+    /// The ownership of instance is transferred and the receiver is responsible for disposing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    internal sealed class TakesOwnershipAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Alternative to the approach taken in https://github.com/DotNetAnalyzers/IDisposableAnalyzers/pull/130

I tested the nupkg and was able to use the attributes in a new console project just by referencing the package. When I added `<IncludeOwnershipAttributes>false</IncludeOwnershipAttributes>` to the csproj, the attributes were no longer declared.

Resulting package file structure:

```diff
 IDisposableAnalyzers.3.3.4
 │   IDisposableAnalyzers.nuspec
 │
 ├───analyzers
 │   └───dotnet
 │       └───cs
 │               Gu.Roslyn.Extensions.dll
 │               IDisposableAnalyzers.dll
 │
+├───build
+│       IDisposableAnalyzers.targets
+│       OwnershipAttributes.cs
 │
 └───tools
         install.ps1
         uninstall.ps1
```