### PR TITLE
Resolved issue #235

### DIFF
--- a/IDisposableAnalyzers.NetCoreTests/IDISP002DisposeMemberTests/CodeFix.cs
+++ b/IDisposableAnalyzers.NetCoreTests/IDISP002DisposeMemberTests/CodeFix.cs
@@ -223,5 +223,200 @@ namespace N
 
             RoslynAssert.NoFix(Analyzer, Fix, ExpectedDiagnostic, code);
         }
+
+        [Test]
+        public static void FieldConvertibleToIDisposable()
+        {
+            var before = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+
+    sealed class C : IDisposable
+    {
+        ↓private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+        }
+    }
+}";
+
+            var after = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+
+    sealed class C : IDisposable
+    {
+        private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+            ((IDisposable)this.disposable).Dispose();
+        }
+    }
+}";
+            RoslynAssert.CodeFix(Analyzer, Fix, ExpectedDiagnostic, before, after);
+        }
+
+        [Test]
+        public static void FieldConvertibleToIDisposableAndIAsyncDisposable1()
+        {
+            var before = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        ↓private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+            ((IDisposable)this.disposable).Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+        }
+    }
+}";
+
+            var after = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+            ((IDisposable)this.disposable).Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ((IAsyncDisposable)this.disposable).DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}";
+            RoslynAssert.CodeFix(Analyzer, Fix, ExpectedDiagnostic, before, after);
+        }
+
+        [Test]
+        public static void FieldConvertibleToIDisposableAndIAsyncDisposable2()
+        {
+            var before = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        ↓private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ((IAsyncDisposable)this.disposable).DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}";
+
+            var after = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+            ((IDisposable)this.disposable).Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ((IAsyncDisposable)this.disposable).DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}";
+            RoslynAssert.CodeFix(Analyzer, Fix, ExpectedDiagnostic, before, after);
+        }
+
+        [Test]
+        public static void FieldConvertibleToIDisposableAndIAsyncDisposable3()
+        {
+            var before = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        ↓private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+        }
+    }
+}";
+
+            var after = @"
+#nullable enable
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    sealed class C : IDisposable, IAsyncDisposable
+    {
+        private readonly object disposable = File.OpenRead(string.Empty);
+
+        public void Dispose()
+        {
+            ((IDisposable)this.disposable).Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await ((IAsyncDisposable)this.disposable).DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}";
+            RoslynAssert.FixAll(Analyzer, Fix, ExpectedDiagnostic, before, after);
+        }
     }
 }

--- a/IDisposableAnalyzers/CodeFixes/Helpers/IDisposableFactory.cs
+++ b/IDisposableAnalyzers/CodeFixes/Helpers/IDisposableFactory.cs
@@ -164,9 +164,10 @@
                     }
 
                     return DisposeStatement(
-                            SyntaxFactory.CastExpression(
+                            SyntaxFactory.ParenthesizedExpression(
+                                SyntaxFactory.CastExpression(
                                 SystemIDisposable,
-                                neverNull.WithoutTrivia()))
+                                neverNull.WithoutTrivia())))
                         .WithLeadingElasticLineFeed();
                 case { MaybeNull: { } maybeNull }:
                     if (DisposeMethod.IsAccessibleOn(disposable.Type, semanticModel.Compilation))


### PR DESCRIPTION
Added parentheses when the member type can be cast to `IDisposable` or `IAsyncDisposable`.
Added unit tests for these cases. I've only added them under `NetCoreTests` as this seemed to be where the most recent check-ins had been.