### PR TITLE
Add analyzer IDISP026 for marking classes with IAsyncDisposable as sealed.

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP026SealAsyncDisposableTests/CodeFix.cs
+++ b/IDisposableAnalyzers.Test/IDISP026SealAsyncDisposableTests/CodeFix.cs
@@ -1,4 +1,4 @@
-﻿namespace IDisposableAnalyzers.Test.IDISP025SealDisposableTests
+﻿namespace IDisposableAnalyzers.Test.IDISP026SealAsyncDisposableTests
 {
     using Gu.Roslyn.Asserts;
     using NUnit.Framework;
@@ -7,7 +7,7 @@
     {
         private static readonly ClassDeclarationAnalyzer Analyzer = new();
         private static readonly SealFix Fix = new();
-        private static readonly ExpectedDiagnostic ExpectedDiagnostic = ExpectedDiagnostic.Create(Descriptors.IDISP025SealDisposable);
+        private static readonly ExpectedDiagnostic ExpectedDiagnostic = ExpectedDiagnostic.Create(Descriptors.IDISP026SealAsyncDisposable);
 
         [Test]
         public static void Simple()
@@ -16,11 +16,13 @@
 namespace N
 {
     using System;
+    using System.Threading.Tasks;
 
-    public class ↓C : IDisposable
+    public class ↓C : IAsyncDisposable
     {
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
+            return ValueTask.CompletedTask;
         }
     }
 }";
@@ -29,14 +31,16 @@ namespace N
 namespace N
 {
     using System;
+    using System.Threading.Tasks;
 
-    public sealed class C : IDisposable
+    public sealed class C : IAsyncDisposable
     {
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
+            return ValueTask.CompletedTask;
         }
     }
-}";
+}"; ;
             RoslynAssert.CodeFix(Analyzer, Fix, ExpectedDiagnostic, before, after);
         }
     }

--- a/IDisposableAnalyzers.Test/IDISP026SealAsyncDisposableTests/Valid.cs
+++ b/IDisposableAnalyzers.Test/IDISP026SealAsyncDisposableTests/Valid.cs
@@ -1,0 +1,88 @@
+﻿namespace IDisposableAnalyzers.Test.IDISP026SealAsyncDisposableTests
+{
+    using Gu.Roslyn.Asserts;
+    using NUnit.Framework;
+
+    public static class Valid
+    {
+        private static readonly ClassDeclarationAnalyzer Analyzer = new();
+
+        public static class DisposeAsync
+        {
+            [Test]
+            public static void SealedSimple()
+            {
+                var code = @"
+namespace N
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public sealed class C : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}";
+                RoslynAssert.Valid(Analyzer, code);
+            }
+
+            [Test]
+            public static void SealedPartial()
+            {
+                var part1 = @"
+namespace N
+{
+    using System;
+
+    public sealed partial class C : IAsyncDisposable
+    {
+    }
+}";
+
+                var part2 = @"
+namespace N
+{
+    using System.Threading.Tasks;
+
+    public sealed partial class C
+    {
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}";
+                RoslynAssert.Valid(Analyzer, part1, part2);
+            }
+
+            [Test]
+            public static void WithDisposeAsyncCore()
+            {
+                var code = @"
+namespace N
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class C : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await this.DisposeAsyncCore();
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual ValueTask DisposeAsyncCore()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}";
+                RoslynAssert.Valid(Analyzer, code);
+            }
+        }
+    }
+}

--- a/IDisposableAnalyzers/Analyzers/ClassDeclarationAnalyzer.cs
+++ b/IDisposableAnalyzers/Analyzers/ClassDeclarationAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿namespace IDisposableAnalyzers
 {
     using System.Collections.Immutable;
-
     using Gu.Roslyn.AnalyzerExtensions;
 
     using Microsoft.CodeAnalysis;
@@ -13,7 +12,7 @@
     internal class ClassDeclarationAnalyzer : DiagnosticAnalyzer
     {
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
-            Descriptors.IDISP025SealDisposable);
+            Descriptors.IDISP025SealDisposable, Descriptors.IDISP026SealAsyncDisposable);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -24,15 +23,49 @@
 
         private static void Handle(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is ClassDeclarationSyntax classDeclaration &&
-                context.ContainingSymbol is INamedTypeSymbol { IsSealed: false } type &&
-                type.IsAssignableTo(KnownSymbols.IDisposable, context.SemanticModel.Compilation) &&
-                DisposeMethod.Find(type, context.Compilation, Search.TopLevel) is { IsVirtual: false, IsAbstract: false, IsOverride: false } disposeMethod &&
-                !HasDisposeDisposing(type))
+            if (context.Node is not ClassDeclarationSyntax classDeclaration)
             {
+                return;
+            }
+
+            if (context.ContainingSymbol is not INamedTypeSymbol { IsSealed: false } type)
+            {
+                return;
+            }
+
+            if (type.IsAssignableTo(KnownSymbols.IDisposable, context.SemanticModel.Compilation))
+            {
+                if (HasDisposeDisposing(type))
+                {
+                    return;
+                }
+
+                if (DisposeMethod.Find(type, context.Compilation, Search.TopLevel) is not { IsVirtual: false, IsAbstract: false, IsOverride: false } disposeMethod)
+                {
+                    return;
+                }
+
                 context.ReportDiagnostic(
                     Diagnostic.Create(
                         Descriptors.IDISP025SealDisposable,
+                        classDeclaration.Identifier.GetLocation(),
+                        additionalLocations: new[] { disposeMethod.Locations[0] }));
+            }
+            else if (type.IsAssignableTo(KnownSymbols.IAsyncDisposable, context.SemanticModel.Compilation))
+            {
+                if (DisposeMethod.FindDisposeAsync(type, context.Compilation, Search.TopLevel) is not { IsAbstract: false, IsOverride: false } disposeMethod)
+                {
+                    return;
+                }
+
+                if (HasDisposeAsyncCore(type))
+                {
+                    return;
+                }
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        Descriptors.IDISP026SealAsyncDisposable,
                         classDeclaration.Identifier.GetLocation(),
                         additionalLocations: new[] { disposeMethod.Locations[0] }));
             }
@@ -44,6 +77,21 @@
             {
                 if (member is IMethodSymbol { ReturnsVoid: true, Name: "Dispose", Parameters: { Length: 1 } parameters } &&
                     parameters[0].Type.SpecialType == SpecialType.System_Boolean)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasDisposeAsyncCore(INamedTypeSymbol type)
+        {
+            // Types with IAsyncDisposable should have DisposeAsyncCore
+            // https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#:~:text=A%20protected%20virtual%20ValueTask%20DisposeAsyncCore()%20method%20whose%20signature%20is%3A
+            foreach (var member in type.GetMembers("DisposeAsyncCore"))
+            {
+                if (member is IMethodSymbol { Name: "DisposeAsyncCore", IsVirtual: true, ReturnType.MetadataName: "ValueTask", Parameters.IsEmpty: true })
                 {
                     return true;
                 }

--- a/IDisposableAnalyzers/CodeFixes/SealFix.cs
+++ b/IDisposableAnalyzers/CodeFixes/SealFix.cs
@@ -13,7 +13,7 @@
     internal class SealFix : DocumentEditorCodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
-            Descriptors.IDISP025SealDisposable.Id);
+            Descriptors.IDISP025SealDisposable.Id, Descriptors.IDISP026SealAsyncDisposable.Id);
 
         protected override DocumentEditorFixAllProvider? FixAllProvider() => null;
 

--- a/IDisposableAnalyzers/Descriptors.cs
+++ b/IDisposableAnalyzers/Descriptors.cs
@@ -229,6 +229,15 @@
             isEnabledByDefault: true,
             description: "Class with no virtual dispose method should be sealed.");
 
+        internal static readonly DiagnosticDescriptor IDISP026SealAsyncDisposable = Create(
+            id: "IDISP026",
+            title: "Class with no virtual DisposeAsyncCore method should be sealed",
+            messageFormat: "Class with no virtual DisposeAsyncCore method should be sealed",
+            category: AnalyzerCategory.Correctness,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Class with no virtual DisposeAsyncCore method should be sealed.");
+
         /// <summary>
         /// Create a DiagnosticDescriptor, which provides description about a <see cref="Diagnostic" />.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Roslyn analyzers for IDisposable
 | [IDISP023](https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP023.md)| Don't use reference types in finalizer context
 | [IDISP024](https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP024.md)| Don't call GC.SuppressFinalize(this) when the type is sealed and has no finalizer
 | [IDISP025](https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP025.md)| Class with no virtual dispose method should be sealed
+| [IDISP026](https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP026.md)| Class with no virtual DisposeAsyncCore method should be sealed
 | [SyntaxTreeCacheAnalyzer]()| Controls caching of for example semantic models for syntax trees
 
 ## Using IDisposableAnalyzers

--- a/ValidCode.Web/AsyncDisposableCases/Impl1.cs
+++ b/ValidCode.Web/AsyncDisposableCases/Impl1.cs
@@ -4,7 +4,7 @@
     using System.IO;
     using System.Threading.Tasks;
 
-    public class Impl1 : IAsyncDisposable
+    public sealed class Impl1 : IAsyncDisposable
     {
         private readonly IAsyncDisposable disposable = File.OpenRead(string.Empty);
 

--- a/ValidCode.Web/AsyncDisposableCases/Impl2.cs
+++ b/ValidCode.Web/AsyncDisposableCases/Impl2.cs
@@ -4,7 +4,7 @@
     using System.IO;
     using System.Threading.Tasks;
 
-    public class Impl2 : IAsyncDisposable
+    public sealed class Impl2 : IAsyncDisposable
     {
         private readonly IAsyncDisposable disposable = File.OpenRead(string.Empty);
 

--- a/ValidCode.Web/AsyncDisposableCases/Issue199.cs
+++ b/ValidCode.Web/AsyncDisposableCases/Issue199.cs
@@ -4,7 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class Issue199 : IAsyncDisposable
+    public sealed class Issue199 : IAsyncDisposable
     {
         private Timer? _timer;
 

--- a/ValidCode.Web/AsyncDisposableCases/Issue204.cs
+++ b/ValidCode.Web/AsyncDisposableCases/Issue204.cs
@@ -20,7 +20,7 @@
             }
         }
 
-        public class C : IAsyncDisposable
+        public sealed class C : IAsyncDisposable
         {
             private readonly IAsyncDisposable disposable = File.OpenRead(string.Empty);
 

--- a/ValidCode.Web/AsyncDisposableCases/Issue222.cs
+++ b/ValidCode.Web/AsyncDisposableCases/Issue222.cs
@@ -4,7 +4,7 @@
     using System.IO;
     using System.Threading.Tasks;
 
-    public class Issue222 : IAsyncDisposable
+    public sealed class Issue222 : IAsyncDisposable
     {
         private readonly Stream disposable = File.OpenRead(string.Empty);
 

--- a/documentation/IDISP026.md
+++ b/documentation/IDISP026.md
@@ -1,0 +1,50 @@
+# IDISP026
+## Class with no virtual DisposeAsyncCore method should be sealed
+
+| Topic    | Value
+| :--      | :--
+| Id       | IDISP026
+| Severity | Warning
+| Enabled  | True
+| Category | IDisposableAnalyzers.Correctness
+| Code     | [ClassDeclarationAnalyzer](https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/IDisposableAnalyzers/Analyzers/ClassDeclarationAnalyzer.cs)
+
+
+## Description
+
+Class with no virtual DisposeAsyncCore method should be sealed.
+
+When implementing IAsyncDisposable, classes without a virtual DisposeAsyncCore method should be sealed.
+See https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync.
+
+## How to fix violations
+
+Mark classes the implement IAsyncDisposable as sealed.
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable IDISP026 // Class with no virtual DisposeAsyncCore method should be sealed
+Code violating the rule here
+#pragma warning restore IDISP026 // Class with no virtual DisposeAsyncCore method should be sealed
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable IDISP026 // Class with no virtual DisposeAsyncCore method should be sealed
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", 
+    "IDISP026:Class with no virtual DisposeAsyncCore method should be sealed", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->


### PR DESCRIPTION
Fix for this issue: https://github.com/DotNetAnalyzers/IDisposableAnalyzers/issues/374
My point of reference is this official documentation: https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync

I chose to create a separate analyzer, as IAsyncDisposable has a lot of difference to IDisposable. 
Separating it from IDISP026 makes testing a lot less bloated.
If we end up adding this analyzer, the minor version should probably be bumped, but I am not sure how to do that.
