### PR TITLE
Don't trigger IDISP013 when returning ValueTask

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Valid.cs
+++ b/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Valid.cs
@@ -117,6 +117,29 @@ namespace N
     }
 
     [Test]
+    public static void ValueTaskFromResult()
+    {
+        var code = @"
+namespace N
+{
+    using System.IO;
+    using System.Threading.Tasks;
+
+    public class C
+    {
+        public ValueTask<int> M()
+        {
+            using (var stream = File.OpenRead(string.Empty))
+            {
+                return ValueTask.FromResult(1);
+            }
+        }
+    }
+}";
+        RoslynAssert.Valid(Analyzer, code);
+    }
+
+    [Test]
     public static void TaskCompletedTask()
     {
         var code = @"
@@ -132,6 +155,29 @@ namespace N
             using (var stream = File.OpenRead(string.Empty))
             {
                 return Task.CompletedTask;
+            }
+        }
+    }
+}";
+        RoslynAssert.Valid(Analyzer, code);
+    }
+
+    [Test]
+    public static void ValueTaskCompletedTask()
+    {
+        var code = @"
+namespace N
+{
+    using System.IO;
+    using System.Threading.Tasks;
+
+    public class C
+    {
+        public ValueTask M()
+        {
+            using (var stream = File.OpenRead(string.Empty))
+            {
+                return ValueTask.CompletedTask;
             }
         }
     }

--- a/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
+++ b/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
@@ -186,9 +186,11 @@ internal class ReturnValueAnalyzer : DiagnosticAnalyzer
         return returnValue switch
         {
             InvocationExpressionSyntax invocation
-            => !invocation.IsSymbol(KnownSymbols.Task.FromResult, context.SemanticModel, context.CancellationToken),
+            => !(invocation.IsSymbol(KnownSymbols.Task.FromResult, context.SemanticModel, context.CancellationToken)
+                || invocation.IsSymbol(KnownSymbols.ValueTask.FromResult, context.SemanticModel, context.CancellationToken)),
             MemberAccessExpressionSyntax { Name.Identifier.ValueText: "CompletedTask" } memberAccess
-            => !memberAccess.IsSymbol(KnownSymbols.Task.CompletedTask, context.SemanticModel, context.CancellationToken),
+            => !(memberAccess.IsSymbol(KnownSymbols.Task.CompletedTask,   context.SemanticModel, context.CancellationToken)
+                || memberAccess.IsSymbol(KnownSymbols.ValueTask.CompletedTask, context.SemanticModel, context.CancellationToken)),
             _ => true,
         };
     }

--- a/IDisposableAnalyzers/Helpers/KnownSymbols/KnownSymbols.cs
+++ b/IDisposableAnalyzers/Helpers/KnownSymbols/KnownSymbols.cs
@@ -57,6 +57,7 @@ internal static class KnownSymbols
     internal static readonly EnumerableType Enumerable = new();
     internal static readonly QualifiedType ConditionalWeakTable = Create("System.Runtime.CompilerServices.ConditionalWeakTable`2");
     internal static readonly TaskType Task = new();
+    internal static readonly ValueTaskType ValueTask = new();
     internal static readonly QualifiedType ValueTaskOfT = new("System.Threading.Tasks.ValueTask`1");
     internal static readonly QualifiedType TaskOfT = new("System.Threading.Tasks.Task`1");
     internal static readonly QualifiedType CancellationToken = new("System.Threading.CancellationToken");

--- a/IDisposableAnalyzers/Helpers/KnownSymbols/ValueTaskType.cs
+++ b/IDisposableAnalyzers/Helpers/KnownSymbols/ValueTaskType.cs
@@ -1,0 +1,20 @@
+namespace IDisposableAnalyzers;
+
+using Gu.Roslyn.AnalyzerExtensions;
+
+internal class ValueTaskType : QualifiedType
+{
+    internal readonly QualifiedMethod FromResult;
+    internal readonly QualifiedMethod Run;
+    internal readonly QualifiedMethod RunOfT;
+    internal readonly QualifiedMethod ConfigureAwait;
+    internal readonly QualifiedProperty CompletedTask;
+
+    internal ValueTaskType()
+        : base("System.Threading.Tasks.ValueTask")
+    {
+        this.FromResult = new QualifiedMethod(this, nameof(this.FromResult));
+        this.ConfigureAwait = new QualifiedMethod(this, nameof(this.ConfigureAwait));
+        this.CompletedTask = new QualifiedProperty(this, nameof(this.CompletedTask));
+    }
+}


### PR DESCRIPTION
Currently the following will trigger IDISP013, whereas the doing the equivalent with a `Task` will not. I think `ValueTask` should get the same treatment.

```cs
namespace N
{
    using System.IO;
    using System.Threading.Tasks;
    public class C
    {
        public ValueTask<int> M()
        {
            using (var stream = File.OpenRead(string.Empty))
            {
                return ↓ValueTask.FromResult(1);
            }
        }
    }
}
```