### PR TITLE
Fix IDISP013 using declaration in outer scope regression

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Diagnostics.cs
+++ b/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Diagnostics.cs
@@ -87,6 +87,35 @@ namespace N
     }
 
     [Test]
+    public static void UsingDeclarationInner()
+    {
+        var code = @"
+namespace N
+{
+    using System.Threading.Tasks;
+
+    public static class C
+    {
+        public static ValueTask<int> MAsync()
+        {
+            using var file = System.IO.File.OpenRead(string.Empty);
+            while (true)
+            {
+                return ↓InnerAsync();
+            }
+        }
+
+        private static async ValueTask<int> InnerAsync()
+        {
+            await Task.Delay(10).ConfigureAwait(false);
+            return 1;
+        }
+    }
+}";
+        RoslynAssert.Diagnostics(Analyzer, ExpectedDiagnostic, code);
+    }
+
+    [Test]
     public static void LocalTask()
     {
         var code = @"

--- a/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
+++ b/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
@@ -146,7 +146,7 @@ internal class ReturnValueAnalyzer : DiagnosticAnalyzer
             {
                 if (statement.SpanStart >= node.SpanStart)
                 {
-                    return false;
+                    break;
                 }
 
                 if (statement is LocalDeclarationStatementSyntax { UsingKeyword.ValueText: "using" })
@@ -154,6 +154,8 @@ internal class ReturnValueAnalyzer : DiagnosticAnalyzer
                     return true;
                 }
             }
+
+            return node.Parent != null && IsInUsing(node.Parent);
         }
 
         return false;


### PR DESCRIPTION
The rewrite in a048f67b doesn't consider outer scopes which might also contain a `using` declaration.