### PR TITLE
Suppress `IDISP001` for `DisposeWith` at the end of the right hand side of variable assignments

### DIFF
--- a/IDisposableAnalyzers.Test/Helpers/DisposableTests.Stores.cs
+++ b/IDisposableAnalyzers.Test/Helpers/DisposableTests.Stores.cs
@@ -948,8 +948,8 @@ namespace N
             var compilation = CSharpCompilation.Create("test", new[] { syntaxTree }, Settings.Default.MetadataReferences);
             var semanticModel = compilation.GetSemanticModel(syntaxTree);
             var value = syntaxTree.FindParameter("Stream stream");
-            Assert.AreEqual(true,  semanticModel.TryGetSymbol(value, CancellationToken.None, out var symbol));
-            Assert.AreEqual(true,  LocalOrParameter.TryCreate(symbol, out var localOrParameter));
+            Assert.AreEqual(true, semanticModel.TryGetSymbol(value, CancellationToken.None, out var symbol));
+            Assert.AreEqual(true, LocalOrParameter.TryCreate(symbol, out var localOrParameter));
             Assert.AreEqual(true, Disposable.Stores(localOrParameter, semanticModel, CancellationToken.None, out _));
         }
     }

--- a/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Valid.Ignore.cs
+++ b/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Valid.Ignore.cs
@@ -71,4 +71,34 @@ namespace N
 }";
         RoslynAssert.Valid(Analyzer, code);
     }
+
+    [Test]
+    public static void ReactiveUiDisposeWith()
+    {
+        const string Code = """
+            namespace N
+            {
+                using System;
+                using System.Reactive.Disposables;
+                using ReactiveUI;
+                
+                public sealed class C : IDisposable
+                {
+                    private readonly CompositeDisposable _disposables = new();
+                    
+                    public C()
+                    {
+                        var command = ReactiveCommand.Create(() => { Console.WriteLine("Hi"); }).DisposeWith(_disposables);
+                    }
+                    
+                    public void Dispose()
+                    {
+                        _disposables.Dispose();
+                    }
+                }
+            }
+            """;
+
+        RoslynAssert.Valid(Analyzer, Code);
+    }
 }

--- a/IDisposableAnalyzers/Helpers/Disposable.ShouldDispose.cs
+++ b/IDisposableAnalyzers/Helpers/Disposable.ShouldDispose.cs
@@ -118,50 +118,10 @@ internal static partial class Disposable
         }
     }
 
+    // For simplicity reasons, we do not validate the variable type, or what is to the left of the call.
+    // Instead, we simply check if the last invocation of the rhs is `.DisposeWith(<one argument>);`
     private static bool IsVariableDeclarationWithDisposeAsExtensionCall(BlockSyntax localBlock)
-    {
-        if (localBlock is not { Statements: { Count: 1 } statements })
-        {
-            return false;
-        }
-
-        if (statements[0] is not LocalDeclarationStatementSyntax { Declaration: { } variableDeclaration })
-        {
-            return false;
-        }
-
-        if (variableDeclaration.Variables is not { Count: 1 } vars)
-        {
-            return false;
-        }
-
-        if (vars[0].Initializer is not { } rhs)
-        {
-            return false;
-        }
-
-        // For simplicity reasons, we do not validate the variable type, or what is to the left of the call.
-        // Instead, we simply check if the last invocation of the rhs is `.DisposeWith(<one argument>);`
-        if (rhs.Value is not InvocationExpressionSyntax lastInvocationInChain)
-        {
-            return false;
-        }
-
-        if (lastInvocationInChain.Expression is not MemberAccessExpressionSyntax memberAccess)
-        {
-            return false;
-        }
-
-        if (memberAccess.Name.Identifier.Value is not "DisposeWith")
-        {
-            return false;
-        }
-
-        if (lastInvocationInChain.ArgumentList.Arguments is not { Count: 1 } arguments)
-        {
-            return false;
-        }
-
-        return true;
-    }
+        => localBlock is { Statements: { Count: 1 } statements } &&
+           statements[0] is LocalDeclarationStatementSyntax { Declaration.Variables: { Count: 1 } vars } &&
+           vars[0].Initializer is { Value: InvocationExpressionSyntax { ArgumentList.Arguments.Count: 1, Expression: MemberAccessExpressionSyntax { Name.Identifier.Value: "DisposeWith" } } };
 }


### PR DESCRIPTION
Using `ReactiveUI`, I was forced to write

```cs
var disposables = new CompositeDisposable();

var command = ReactiveCommand.Create(() => { .. });
command.DisposeWith(disposables);
```

Because this Analyzer did not allow the `DisposeWith` call to be chained at the end of variable assignments:

```cs
var disposables = new CompositeDisposable();

// Causes IDISP001
var command = ReactiveCommand.Create(() => { .. }).DisposeWith(disposables);
```

This works for chains started from parameters, fields, and variables however (and is even tested):

```cs
public Issue298(IObservable<object> observable)
{
    observable.Subscribe(x => Console.WriteLine(x)).DisposeWith(this.disposable);
}
```

This PR suppresses `IDISP001` for variable assignments as well!