### PR TITLE
Opt-out of Moq's Verify() / Setup() in IDISP013

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Valid.Ignore.cs
+++ b/IDisposableAnalyzers.Test/IDISP013AwaitInUsingTests/Valid.Ignore.cs
@@ -32,5 +32,34 @@ public static partial class Valid
                 """;
             RoslynAssert.Valid(Analyzer, code);
         }
+
+        [Test]
+        public static void MoqSetupVerifyAsync()
+        {
+            var code = @"
+namespace N
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using Moq;
+
+    public class C
+    {
+        public void M()
+        {
+            using (var stream = File.OpenRead(string.Empty))
+            {
+                var mock = new Mock<Stream>();
+                mock.Setup(x => x.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(0);
+                mock.Verify(x => x.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()));
+            }
+        }
+    }
+}";
+
+            RoslynAssert.Valid(Analyzer, code);
+        }
     }
 }

--- a/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
+++ b/IDisposableAnalyzers/Analyzers/ReturnValueAnalyzer.cs
@@ -136,7 +136,7 @@ internal class ReturnValueAnalyzer : DiagnosticAnalyzer
             {
                 if (returnValue.TryFirstAncestor(out InvocationExpressionSyntax? ancestor) &&
                     ancestor.TryGetMethodName(out var ancestorName) &&
-                    ancestorName == "ThrowsAsync")
+                    ancestorName is "ThrowsAsync" or "Setup" or "Verify")
                 {
                     return false;
                 }


### PR DESCRIPTION
This solves issue #370 by exempting methods called `Setup` and `Verify`. This is not an ideal solution, but sort-of in line with the exemption for `ThrowsAsync` that was already there. As the added exemptions have more generic names, this might result in more false negatives. So other ideas to investigate:

- Check the method's assembly namespace, only exempt testing frameworks
- Exempt all async calls made from expressions (`System.Linq.Expression`)

What do you think?

Note that I tested on an earlier version of master which succeeded. However _all_ tests fail to run after rebasing on latest master, probably because the unit tests don't target .NET 8 on macOS.