### PR TITLE
FP IDISP004: All IEnumerables are disposed after executing foreach statements

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP004DoNotIgnoreCreatedTests/Valid.CreatedWithinForEach.cs
+++ b/IDisposableAnalyzers.Test/IDISP004DoNotIgnoreCreatedTests/Valid.CreatedWithinForEach.cs
@@ -1,0 +1,108 @@
+﻿namespace IDisposableAnalyzers.Test.IDISP004DoNotIgnoreCreatedTests;
+
+using Gu.Roslyn.Asserts;
+using NUnit.Framework;
+
+public static partial class Valid
+{
+    [Test]
+    public static void StructEnumeratorCreatedWithinForEach()
+    {
+        var code = @"
+using System.Collections;
+using System.Collections.Generic;
+
+namespace N
+{
+    public class C
+    {
+        public void M()
+        {
+            foreach(var n in new Enumerator())
+            {
+            }
+        }
+    }
+
+    public struct Enumerator : IEnumerator<int>, IEnumerable<int>
+    {
+        public int Current => 42;
+        object IEnumerator.Current => 42;
+        public void Dispose() { }
+        public bool MoveNext() => true;
+        public void Reset() { }
+        public IEnumerator<int> GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+    }
+}";
+        RoslynAssert.Valid(Analyzer, code);
+    }
+
+    [Test]
+    public static void ClassEnumeratorCreatedWithinForEach()
+    {
+        var code = @"
+using System.Collections;
+using System.Collections.Generic;
+
+namespace N
+{
+    public class C
+    {
+        public void M()
+        {
+            foreach(var n in new Enumerator())
+            {
+            }
+        }
+    }
+
+    public class Enumerator : IEnumerator<int>, IEnumerable<int>
+    {
+        public int Current => 42;
+        object IEnumerator.Current => 42;
+        public void Dispose() { }
+        public bool MoveNext() => true;
+        public void Reset() { }
+        public IEnumerator<int> GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+    }
+}";
+        RoslynAssert.Valid(Analyzer, code);
+    }
+
+    [Test]
+    public static void CreatedEnumerableWithinForEach()
+    {
+        var code = @"
+using System.Collections;
+using System.Collections.Generic;
+
+namespace N
+{
+    public class C
+    {
+        public void M()
+        {
+            foreach(var n in All())
+            {
+            }
+        }
+
+        public IEnumerable<int> All() => new Enumerator();
+    }
+
+    public class Enumerator : IEnumerator<int>, IEnumerable<int>
+    {
+        public int Current => 42;
+        object IEnumerator.Current => 42;
+        public void Dispose() { }
+        public bool MoveNext() => true;
+        public void Reset() { }
+        public IEnumerator<int> GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+    }
+}";
+        RoslynAssert.Valid(Analyzer, code);
+    }
+}

--- a/IDisposableAnalyzers/Helpers/Disposable.Disposes.cs
+++ b/IDisposableAnalyzers/Helpers/Disposable.Disposes.cs
@@ -90,6 +90,9 @@ internal static partial class Disposable
                 when Identity(candidate, recursion) is { } id &&
                      Disposes(id, recursion)
                 => true,
+            { Parent: ForEachStatementSyntax parent }
+                when parent.Expression == candidate
+                => true,
             { Parent: ConditionalAccessExpressionSyntax { WhenNotNull: InvocationExpressionSyntax invocation } }
                 => IsDisposeOrReturnValueDisposed(invocation),
             { Parent: MemberAccessExpressionSyntax { Parent: InvocationExpressionSyntax invocation } }


### PR DESCRIPTION
As all `IEnumerable`'s are disposed after executing the `foreach` statement, all their expressions are disposed. Therefor, IDISP004 (Do not ignore created) should not be raised.

Closes #520