### PR TITLE
Directions for supporting IAsyncDisposable

### DIFF
--- a/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Diagnostics.Local.cs
+++ b/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Diagnostics.Local.cs
@@ -24,6 +24,22 @@ public static partial class Diagnostics
             }
             """;
 
+        private const string AsyncDisposable = """
+            namespace N
+            {
+                using System;
+                using System.Threading.Tasks;
+
+                public class AsyncDisposable : IAsyncDisposable
+                {
+                    public ValueTask DisposeAsync()
+                    {
+                        return ValueTask.CompletedTask;
+                    }
+                }
+            }
+            """;
+
         [TestCase("new Disposable()")]
         [TestCase("new Disposable() as object")]
         [TestCase("(object) new Disposable()")]
@@ -162,6 +178,25 @@ public static partial class Diagnostics
                 }
                 """;
             RoslynAssert.Diagnostics(Analyzer, ExpectedDiagnostic, Disposable, code);
+        }
+
+        [Test]
+        public static void NewAsyncDisposable()
+        {
+            var code = """
+                       namespace N
+                       {
+                           public static class C
+                           {
+                               public static long M()
+                               {
+                                   ↓var disposable = new AsyncDisposable();
+                                   return 1;
+                               }
+                           }
+                       }
+                       """;
+            RoslynAssert.Diagnostics(Analyzer, ExpectedDiagnostic, AsyncDisposable, code);
         }
 
         [Test]

--- a/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Valid.cs
+++ b/IDisposableAnalyzers.Test/IDISP001DisposeCreatedTests/Valid.cs
@@ -36,6 +36,22 @@ namespace N
     }
 }";
 
+    private const string AsyncDisposable = """
+            namespace N
+            {
+                using System;
+                using System.Threading.Tasks;
+
+                public class AsyncDisposable : IAsyncDisposable
+                {
+                    public ValueTask DisposeAsync()
+                    {
+                        return ValueTask.CompletedTask;
+                    }
+                }
+            }
+            """;
+
     [TestCase("1")]
     [TestCase("new string(' ', 1)")]
     [TestCase("typeof(IDisposable)")]
@@ -84,6 +100,27 @@ namespace N
 }";
 
         RoslynAssert.Valid(Analyzer, Disposable, code);
+    }
+
+    [Test]
+    public static void WhenDisposingVariableAsync()
+    {
+        var code = @"
+namespace N
+{
+    using System.Threading.Tasks;
+
+    public class C
+    {
+        public async Task M()
+        {
+            var item = new AsyncDisposable();
+            await item.DisposeAsync();
+        }
+    }
+}";
+
+        RoslynAssert.Valid(Analyzer, AsyncDisposable, code);
     }
 
     [Test]

--- a/IDisposableAnalyzers/Helpers/Disposable.cs
+++ b/IDisposableAnalyzers/Helpers/Disposable.cs
@@ -42,16 +42,17 @@ internal static partial class Disposable
         return true;
     }
 
-    internal static bool IsAssignableFrom(ITypeSymbol type, Compilation compilation) => type switch
-    {
-        null => false,
-        //// https://blogs.msdn.microsoft.com/pfxteam/2012/03/25/do-i-need-to-dispose-of-tasks/
-        { ContainingNamespace: { MetadataName: "Tasks", ContainingNamespace: { MetadataName: "Threading", ContainingNamespace.MetadataName: "System" } }, MetadataName: "Task" } => false,
-        INamedTypeSymbol { ContainingNamespace: { MetadataName: "Tasks", ContainingNamespace: { MetadataName: "Threading", ContainingNamespace.MetadataName: "System" } }, MetadataName: "Task`1", TypeArguments: { Length: 1 } arguments }
-            => IsAssignableFrom(arguments[0], compilation),
-        { IsRefLikeType: true } => DisposeMethod.IsAccessibleOn(type, compilation),
-        _ => type.IsAssignableTo(KnownSymbols.IDisposable, compilation),
-    };
+    internal static bool IsAssignableFrom(ITypeSymbol type, Compilation compilation) =>
+        type switch
+        {
+            null => false,
+            //// https://blogs.msdn.microsoft.com/pfxteam/2012/03/25/do-i-need-to-dispose-of-tasks/
+            { ContainingNamespace: { MetadataName: "Tasks", ContainingNamespace: { MetadataName: "Threading", ContainingNamespace.MetadataName: "System" } }, MetadataName: "Task" } => false,
+            INamedTypeSymbol { ContainingNamespace: { MetadataName: "Tasks", ContainingNamespace: { MetadataName: "Threading", ContainingNamespace.MetadataName: "System" } }, MetadataName: "Task`1", TypeArguments: { Length: 1 } arguments }
+                => IsAssignableFrom(arguments[0], compilation),
+            { IsRefLikeType: true } => DisposeMethod.IsAccessibleOn(type, compilation),
+            _ => type.IsAssignableTo(KnownSymbols.IDisposable, compilation) || type.IsAssignableTo(KnownSymbols.IAsyncDisposable, compilation),
+        };
 
     internal static bool IsNop(ExpressionSyntax candidate, SemanticModel semanticModel, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
#375 reports a scenario where `IAsyncDisposable` isn't reported. As a learning experience I tried to identify the changes needed to maybe start supporting that. The attached changes are probably only scratching the surface, as I've only added tests for a few scenarios.

(At the moment the biggest hurdle for me is that the project requires .net6 which is out of support and I cannot get the tests to succeed on macOS, for which I'll create a separate issue.)

Do you think I should spend more effort into building out this PR, to see it eventually merged? Or do you have other plans/efforts into supporting this?