### PR TITLE
Fixed false warning for IDISP010 when using abstract override

### DIFF
--- a/IDisposableAnalyzers/Analyzers/DisposeMethodAnalyzer.cs
+++ b/IDisposableAnalyzers/Analyzers/DisposeMethodAnalyzer.cs
@@ -112,7 +112,7 @@ internal class DisposeMethodAnalyzer : DiagnosticAnalyzer
 
     private static bool ShouldCallBase(SymbolAndDeclaration<IMethodSymbol, MethodDeclarationSyntax> method, SyntaxNodeAnalysisContext context)
     {
-        if (method is { Symbol: { IsOverride: true, OverriddenMethod: { } overridden } } &&
+        if (method is { Symbol: { IsOverride: true, OverriddenMethod: { IsAbstract: false } overridden } } &&
             DisposeMethod.FindBaseCall(method.Declaration, context.SemanticModel, context.CancellationToken) is null)
         {
             if (overridden.DeclaringSyntaxReferences.Length == 0)


### PR DESCRIPTION
Fixed #575

I found out that the bug was introduced by using external abstract overrides. I fixed this to exclude checking if a class is abstract as they do not implement Disposables, so you do not have to call them.

In addition, added two test to test the abstract behavior